### PR TITLE
feat: add text file reading endpoint

### DIFF
--- a/api.http
+++ b/api.http
@@ -37,4 +37,7 @@ Content-Type: application/json
   "year": 2010
 }
 
+### leer archivo de texto
+GET http://localhost:1234/movies/text
+
 

--- a/controllers/movies.js
+++ b/controllers/movies.js
@@ -1,5 +1,7 @@
 import { MovieModel } from '../models/movie.js'
 import { validateMovie, validarPartialMovie } from '../schemas/movies.js'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
 
 export class MovieController {
     // aqui recupera la request y la response 
@@ -35,7 +37,7 @@ export class MovieController {
       }
       return res.json({ message: 'Movie deleted' });
     }
-    static async update(req, res){ 
+    static async update(req, res){
         const result = validarPartialMovie(req.body)
         if(!result.success){
             return res.status(400).json({error: JSON.parse(result.error.message)})
@@ -44,6 +46,16 @@ export class MovieController {
         const { id } = req.params
         const updatedMovie = await MovieModel.update({id, input: result.data})
 
-        return res.status(200).json(updatedMovie) 
+        return res.status(200).json(updatedMovie)
+    }
+
+    static async getText (req, res) {
+        try {
+            const filePath = join(process.cwd(), 'movies.txt')
+            const content = await readFile(filePath, 'utf8')
+            res.type('text/plain').send(content)
+        } catch (e) {
+            res.status(500).json({ message: 'Error reading text file' })
+        }
     }
 }

--- a/movies.txt
+++ b/movies.txt
@@ -1,0 +1,4 @@
+Esta es una lista de peliculas en texto.
+1. El Padrino
+2. Star Wars
+3. Inception

--- a/routes/movies.js
+++ b/routes/movies.js
@@ -2,13 +2,14 @@ import { Router } from 'express'
 
 import { MovieController } from '../controllers/movies.js'
 
-export const moviesRouter = Router() 
+export const moviesRouter = Router()
 
-moviesRouter.get('/', MovieController.getAll )// esto seria para manejar por un lado el error y por otro lado el resultado 
+moviesRouter.get('/', MovieController.getAll )// esto seria para manejar por un lado el error y por otro lado el resultado
+moviesRouter.get('/text', MovieController.getText )
 moviesRouter.get('/:id', MovieController.getById )
 moviesRouter.post('/', MovieController.create )
 moviesRouter.delete('/:id', MovieController.delete )
-moviesRouter.patch('/:id', MovieController.update )  
+moviesRouter.patch('/:id', MovieController.update )
 
 
 


### PR DESCRIPTION
## Summary
- expose `/movies/text` endpoint to return contents of a text file
- document the new route in api.http and add sample text file

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aa83b0afa4832797c37728bc5e8a3f